### PR TITLE
Fix CSS building

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "start": "nodemon --watch webpack.config.js --exec \"webpack-dev-server --env development\"",
+    "start": "nodemon --watch webpack.config.js --exec \"webpack-dev-server --env.target development\"",
     "build": "webpack --env.target production",
     "lint:js": "eslint app/ webpack.*.js --cache",
     "lint:style": "stylelint app/**/*.css"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,7 @@ const developmentConfig = merge([
 ]);
 
 module.exports = (env) => {
-  if (env === 'production') {
+  if (env.target === 'production') {
     return merge(commonConfig, productionConfig);
   }
 


### PR DESCRIPTION
You made a small mistake in the usage of the `--env` option of Webpack. You start the development cycle by running `--env development` (String), but run production by using the object syntax `--env.target production`. 

Your check for production checked if `env` equals the string `production` which it doesn't. Because you run `--env.target`; `env` equals an object: `{ target: 'production' }`.

This PR fixes this issue by changing the dev command to also utilize the object syntax `--env.target development` and changing the `production` string check to check the object key `target`.

